### PR TITLE
chore: support i18n-ally

### DIFF
--- a/.vscode/extensitions.json
+++ b/.vscode/extensitions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "lokalise.i18n-ally"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,14 @@
   },
   "files.readonlyInclude": {
     "**/routeTree.gen.ts": true
-  }
+  },
+  "i18n-ally.localesPaths": [
+    "src/i18n/locales"
+  ],
+  "i18n-ally.enabledFrameworks": ["react-i18next"],
+  "i18n-ally.sourceLanguage": "en-us",
+  "i18n-ally.displayLanguage": "en-us",
+  "i18n-ally.keystyle": "nested",
+  "i18n-ally.namespace": false,
+  "i18n-ally.pathMatcher": "{locale}/{namespace}.json"
 }


### PR DESCRIPTION
考慮支援 [i18n-ally](https://github.com/lokalise/i18n-ally) 嗎，這樣維護多語言之後會很方便的
vscode 裝上後能檢視其他語言翻譯用詞和翻譯進度等等更多功能，**zh-HK 的翻譯僅僅是自己測試，這份 PR 沒有做新增語言的改動**

<img width="226" height="79" alt="image" src="https://github.com/user-attachments/assets/43db2f21-39ef-4300-8d74-053601938c4b" />

<br/>

<img width="359" height="249" alt="image" src="https://github.com/user-attachments/assets/482973e6-3a13-47b1-a181-9d2cacf55209" />

<br/>

<img width="495" height="576" alt="image" src="https://github.com/user-attachments/assets/6d89c36b-8498-43b3-9fb1-592e83dc6cc4" />
